### PR TITLE
Feature/language export

### DIFF
--- a/core/src/main/java/de/paul2708/commands/core/language/DefaultLanguageSelector.java
+++ b/core/src/main/java/de/paul2708/commands/core/language/DefaultLanguageSelector.java
@@ -1,5 +1,6 @@
 package de.paul2708.commands.core.language;
 
+import com.sun.tools.internal.xjc.Language;
 import de.paul2708.commands.language.LanguageProvider;
 import de.paul2708.commands.language.MessageResource;
 import org.bukkit.command.CommandSender;
@@ -8,6 +9,7 @@ import org.bukkit.entity.Player;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.MissingResourceException;
 import java.util.UUID;
 
 /**
@@ -17,7 +19,7 @@ import java.util.UUID;
  */
 public final class DefaultLanguageSelector implements LanguageSelector {
 
-    // TODO: Check non-existing locales
+    private String directory;
 
     private final Map<UUID, Locale> languages;
     private Locale consoleLanguage;
@@ -28,6 +30,20 @@ public final class DefaultLanguageSelector implements LanguageSelector {
     public DefaultLanguageSelector() {
         this.languages = new HashMap<>();
         this.consoleLanguage = LanguageProvider.DEFAULT_LOCALE;
+    }
+
+    /**
+     * Load the language files from a certain path.
+     *
+     * @param path directory of all <code>message_XX.properties</code>, relative to spigot.jar
+     */
+    @Override
+    public void loadFromFile(String path) throws MissingResourceException {
+        if (directory != null) {
+            throw new IllegalStateException("File aready set.");
+        }
+
+        this.directory = path;
     }
 
     /**
@@ -43,9 +59,9 @@ public final class DefaultLanguageSelector implements LanguageSelector {
         if (sender instanceof Player) {
             Player player = (Player) sender;
 
-            languages.put(player.getUniqueId(), locale);
+            languages.put(player.getUniqueId(), provideLanguage(locale).getLocale());
         } else {
-            this.consoleLanguage = locale;
+            this.consoleLanguage = provideLanguage(locale).getLocale();
         }
     }
 
@@ -57,7 +73,7 @@ public final class DefaultLanguageSelector implements LanguageSelector {
      */
     @Override
     public void sendMessage(CommandSender sender, MessageResource resource) {
-        sender.sendMessage(LanguageProvider.of(get(sender)).translate(resource));
+        sender.sendMessage(provideLanguage(get(sender)).translate(resource));
     }
 
     /**
@@ -69,7 +85,7 @@ public final class DefaultLanguageSelector implements LanguageSelector {
      */
     @Override
     public String translate(CommandSender sender, MessageResource resource) {
-        return LanguageProvider.of(get(sender)).translate(resource);
+        return provideLanguage(get(sender)).translate(resource);
     }
 
     /**
@@ -88,6 +104,14 @@ public final class DefaultLanguageSelector implements LanguageSelector {
             return languages.getOrDefault(player.getUniqueId(), LanguageProvider.DEFAULT_LOCALE);
         } else {
             return consoleLanguage;
+        }
+    }
+
+    private LanguageProvider provideLanguage(Locale locale) {
+        if (directory == null) {
+            return LanguageProvider.of(locale);
+        } else {
+            return LanguageProvider.of(directory, locale);
         }
     }
 }

--- a/core/src/main/java/de/paul2708/commands/core/language/DefaultLanguageSelector.java
+++ b/core/src/main/java/de/paul2708/commands/core/language/DefaultLanguageSelector.java
@@ -1,6 +1,5 @@
 package de.paul2708.commands.core.language;
 
-import com.sun.tools.internal.xjc.Language;
 import de.paul2708.commands.language.LanguageProvider;
 import de.paul2708.commands.language.MessageResource;
 import org.bukkit.command.CommandSender;

--- a/core/src/main/java/de/paul2708/commands/core/language/LanguageSelector.java
+++ b/core/src/main/java/de/paul2708/commands/core/language/LanguageSelector.java
@@ -1,6 +1,5 @@
 package de.paul2708.commands.core.language;
 
-import de.paul2708.commands.core.annotation.Command;
 import de.paul2708.commands.language.MessageResource;
 import org.bukkit.command.CommandSender;
 
@@ -13,6 +12,14 @@ import java.util.Locale;
  * @author Paul2708
  */
 public interface LanguageSelector {
+
+    /**
+     * Load the language files from a certain path.
+     * If the directory doesn't exist, the default resources will be created and loaded there.
+     *
+     * @param path directory of all <code>message_XX.properties</code>, relative to spigot.jar
+     */
+    void loadFromFile(String path);
 
     /**
      * Select the language for a given command sender.

--- a/language/src/main/java/de/paul2708/commands/language/LanguageProvider.java
+++ b/language/src/main/java/de/paul2708/commands/language/LanguageProvider.java
@@ -42,4 +42,15 @@ public interface LanguageProvider {
     static LanguageProvider of(String directory, Locale locale) {
         return new LocaleLanguageProvider(directory, locale);
     }
+
+    /**
+     * Create a new instance to the given locale.
+     * If there is no resource bundle for the given locale, the {@link #DEFAULT_LOCALE} will be used instead.
+     *
+     * @param locale locale
+     * @return new language provider instance
+     */
+    static LanguageProvider of(Locale locale) {
+        return new LocaleLanguageProvider(locale);
+    }
 }

--- a/language/src/main/java/de/paul2708/commands/language/LanguageProvider.java
+++ b/language/src/main/java/de/paul2708/commands/language/LanguageProvider.java
@@ -27,10 +27,11 @@ public interface LanguageProvider {
      * Create a new instance to the given locale.
      * If there is no resource bundle for the given locale, the {@link #DEFAULT_LOCALE} will be used instead.
      *
+     * @param directory file path to the directory of all message properties
      * @param locale locale
      * @return new language provider instance
      */
-    static LanguageProvider of(Locale locale) {
-        return new LocaleLanguageProvider(locale);
+    static LanguageProvider of(String directory, Locale locale) {
+        return new LocaleLanguageProvider(directory, locale);
     }
 }

--- a/language/src/main/java/de/paul2708/commands/language/LanguageProvider.java
+++ b/language/src/main/java/de/paul2708/commands/language/LanguageProvider.java
@@ -24,6 +24,14 @@ public interface LanguageProvider {
     String translate(MessageResource resource);
 
     /**
+     * Get the locale used in {@link #of(String, Locale)}.
+     * If the locale doesn't exist, the default locale will be used.
+     *
+     * @return locale
+     */
+    Locale getLocale();
+
+    /**
      * Create a new instance to the given locale.
      * If there is no resource bundle for the given locale, the {@link #DEFAULT_LOCALE} will be used instead.
      *

--- a/language/src/main/java/de/paul2708/commands/language/LocaleLanguageProvider.java
+++ b/language/src/main/java/de/paul2708/commands/language/LocaleLanguageProvider.java
@@ -26,6 +26,8 @@ public final class LocaleLanguageProvider implements LanguageProvider {
     private ResourceBundle resourceBundle;
     private final String prefix;
 
+    private Locale locale;
+
     /**
      * Create a new language provider based on a locale.
      *
@@ -40,8 +42,12 @@ public final class LocaleLanguageProvider implements LanguageProvider {
 
         try (InputStream inputStream = new FileInputStream(file)) {
             this.resourceBundle =  new PropertyResourceBundle(inputStream);
+
+            this.locale = locale;
         } catch (MissingResourceException | IOException e) {
             this.resourceBundle = ResourceBundle.getBundle(LocaleLanguageProvider.BUNDLE, locale);
+
+            this.locale = resourceBundle.getLocale();
         }
 
         this.prefix = replaceColorCodes(resourceBundle.getString(LocaleLanguageProvider.PREFIX_KEY));
@@ -67,6 +73,17 @@ public final class LocaleLanguageProvider implements LanguageProvider {
                 prefix);
 
         return MessageFormat.format(replaceColorCodes(message), arguments);
+    }
+
+    /**
+     * Get the locale used in {@link #of(String, Locale)}.
+     * If the locale doesn't exist, the default locale will be used.
+     *
+     * @return locale
+     */
+    @Override
+    public Locale getLocale() {
+        return locale;
     }
 
     /**

--- a/language/src/main/java/de/paul2708/commands/language/LocaleLanguageProvider.java
+++ b/language/src/main/java/de/paul2708/commands/language/LocaleLanguageProvider.java
@@ -1,7 +1,13 @@
 package de.paul2708.commands.language;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.text.MessageFormat;
 import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 
 /**
@@ -11,24 +17,33 @@ import java.util.ResourceBundle;
  */
 public final class LocaleLanguageProvider implements LanguageProvider {
 
-    private static final String PATH = "messages";
+    private static final String BUNDLE = "messages";
 
     private static final String PREFIX_KEY = "prefix";
 
     private static final String REPLACE_CHAR = "%";
 
-    private final ResourceBundle resourceBundle;
+    private ResourceBundle resourceBundle;
     private final String prefix;
 
     /**
      * Create a new language provider based on a locale.
      *
+     * @param directory absolute file path to the directory of all message properties
      * @param locale locale
      */
-    LocaleLanguageProvider(Locale locale) {
+    LocaleLanguageProvider(String directory, Locale locale) {
         Locale.setDefault(LanguageProvider.DEFAULT_LOCALE);
 
-        this.resourceBundle = ResourceBundle.getBundle(LocaleLanguageProvider.PATH, locale);
+        File file = new File(directory + "/" + LocaleLanguageProvider.BUNDLE + "_"
+                + locale.getLanguage() + ".properties");
+
+        try (InputStream inputStream = new FileInputStream(file)) {
+            this.resourceBundle =  new PropertyResourceBundle(inputStream);
+        } catch (MissingResourceException | IOException e) {
+            this.resourceBundle = ResourceBundle.getBundle(LocaleLanguageProvider.BUNDLE, locale);
+        }
+
         this.prefix = replaceColorCodes(resourceBundle.getString(LocaleLanguageProvider.PREFIX_KEY));
     }
 

--- a/language/src/main/java/de/paul2708/commands/language/LocaleLanguageProvider.java
+++ b/language/src/main/java/de/paul2708/commands/language/LocaleLanguageProvider.java
@@ -54,6 +54,20 @@ public final class LocaleLanguageProvider implements LanguageProvider {
     }
 
     /**
+     * Create a new language provider based on a locale.
+     *
+     * @param locale locale
+     */
+    LocaleLanguageProvider(Locale locale) {
+        Locale.setDefault(LanguageProvider.DEFAULT_LOCALE);
+
+        this.resourceBundle = ResourceBundle.getBundle(LocaleLanguageProvider.BUNDLE, locale);
+        this.locale = resourceBundle.getLocale();
+
+        this.prefix = replaceColorCodes(resourceBundle.getString(LocaleLanguageProvider.PREFIX_KEY));
+    }
+
+    /**
      * Get the translated message by key.
      *
      * @param resource message resource that contains key and parameters

--- a/language/src/test/java/DefaultLanguageProviderTest.java
+++ b/language/src/test/java/DefaultLanguageProviderTest.java
@@ -1,0 +1,60 @@
+import de.paul2708.commands.language.LanguageProvider;
+import de.paul2708.commands.language.MessageResource;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This test class tests the {@link LanguageProvider}.
+ *
+ * @author Paul2708
+ */
+public final class DefaultLanguageProviderTest {
+
+    // TODO: Add abstract test class that combines both
+
+    /**
+     * Test if the prefix is correct.
+     */
+    @Test
+    public void testColorCodes() {
+        String prefix = LanguageProvider.of(LanguageProvider.DEFAULT_LOCALE).translate(MessageResource.of("prefix"));
+
+        assertEquals("§8[§9Simple-Commands§8]§7", prefix);
+    }
+
+    /**
+     * Test german language detection.
+     */
+    @Test
+    public void testGerman() {
+        LanguageProvider provider = LanguageProvider.of(Locale.GERMAN);
+
+        assertEquals(Locale.GERMAN, provider.getLocale());
+        assertEquals("deutsch", provider.translate(MessageResource.of("language")));
+    }
+
+    /**
+     * Test english language detection.
+     */
+    @Test
+    public void testEnglish() {
+        LanguageProvider provider = LanguageProvider.of(Locale.ENGLISH);
+
+        assertEquals(Locale.ENGLISH, provider.getLocale());
+        assertEquals("english", provider.translate(MessageResource.of("language")));
+    }
+
+    /**
+     * Test if the default language will be applied, if the language is not supported yet.
+     */
+    @Test
+    public void testInvalidLocale() {
+        LanguageProvider provider = LanguageProvider.of(Locale.JAPANESE);
+
+        assertEquals(Locale.ENGLISH, provider.getLocale());
+        assertEquals("english", provider.translate(MessageResource.of("language")));
+    }
+}

--- a/language/src/test/java/LanguageProviderTest.java
+++ b/language/src/test/java/LanguageProviderTest.java
@@ -32,6 +32,7 @@ public final class LanguageProviderTest {
     public void testGerman() {
         LanguageProvider provider = LanguageProvider.of(PATH, Locale.GERMAN);
 
+        assertEquals(Locale.GERMAN, provider.getLocale());
         assertEquals("deutsch", provider.translate(MessageResource.of("language")));
     }
 
@@ -42,6 +43,7 @@ public final class LanguageProviderTest {
     public void testEnglish() {
         LanguageProvider provider = LanguageProvider.of(PATH, Locale.ENGLISH);
 
+        assertEquals(Locale.ENGLISH, provider.getLocale());
         assertEquals("english", provider.translate(MessageResource.of("language")));
     }
 
@@ -52,6 +54,7 @@ public final class LanguageProviderTest {
     public void testInvalidLocale() {
         LanguageProvider provider = LanguageProvider.of(PATH, Locale.JAPANESE);
 
+        assertEquals(Locale.ENGLISH, provider.getLocale());
         assertEquals("english", provider.translate(MessageResource.of("language")));
     }
 }

--- a/language/src/test/java/LanguageProviderTest.java
+++ b/language/src/test/java/LanguageProviderTest.java
@@ -13,12 +13,14 @@ import static org.junit.Assert.assertEquals;
  */
 public final class LanguageProviderTest {
 
+    private static final String PATH = "src/test/resources/";
+
     /**
      * Test if the prefix is correct.
      */
     @Test
     public void testColorCodes() {
-        String prefix = LanguageProvider.of(LanguageProvider.DEFAULT_LOCALE).translate(MessageResource.of("prefix"));
+        String prefix = LanguageProvider.of(PATH, LanguageProvider.DEFAULT_LOCALE).translate(MessageResource.of("prefix"));
 
         assertEquals("§8[§9Simple-Commands§8]§7", prefix);
     }
@@ -28,7 +30,7 @@ public final class LanguageProviderTest {
      */
     @Test
     public void testGerman() {
-        LanguageProvider provider = LanguageProvider.of(Locale.GERMAN);
+        LanguageProvider provider = LanguageProvider.of(PATH, Locale.GERMAN);
 
         assertEquals("deutsch", provider.translate(MessageResource.of("language")));
     }
@@ -38,7 +40,7 @@ public final class LanguageProviderTest {
      */
     @Test
     public void testEnglish() {
-        LanguageProvider provider = LanguageProvider.of(Locale.ENGLISH);
+        LanguageProvider provider = LanguageProvider.of(PATH, Locale.ENGLISH);
 
         assertEquals("english", provider.translate(MessageResource.of("language")));
     }
@@ -48,7 +50,7 @@ public final class LanguageProviderTest {
      */
     @Test
     public void testInvalidLocale() {
-        LanguageProvider provider = LanguageProvider.of(Locale.JAPANESE);
+        LanguageProvider provider = LanguageProvider.of(PATH, Locale.JAPANESE);
 
         assertEquals("english", provider.translate(MessageResource.of("language")));
     }

--- a/language/src/test/resources/messages_de.properties
+++ b/language/src/test/resources/messages_de.properties
@@ -1,0 +1,2 @@
+language=deutsch
+prefix=&8[&9Simple-Commands&8]&7

--- a/language/src/test/resources/messages_en.properties
+++ b/language/src/test/resources/messages_en.properties
@@ -1,0 +1,2 @@
+language=english
+prefix=&8[&9Simple-Commands&8]&7


### PR DESCRIPTION
# Pull Request Template

## Checklist
_Make sure that you completed the following actions to submitting this PR._

* [X] There is an existing issue report for this PR. If not so, create one first.
* [X] I have forked this project.
* [X] I have created a feature branch.
* [X] My changes have been committed.
* [X] I have pushed my changes to the branch.
* [X] Running `mvn checkstyle:checkstyle` doesn't fail.

## Title
Load language by file

## Description
The `LanguageSelector` can load the resource bundle by file instead of using the internal ones.
If the directory or the locale files are missing, the default language will be used instead.

## Issue Resolution
This Pull Request addresses and resolves #15 

## Proposed Changes
* Added directory to language module to load resource bundles from a different file
* Load the directory by `LanguageSelector` in users api