### PR TITLE
Checkstyle will only fail on checkstyle:check instead of each build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ jdk: openjdk8
 
 script:
   - mvn clean install
-  - mvn checkstyle:checkstyle
+  - mvn checkstyle:check

--- a/pom.xml
+++ b/pom.xml
@@ -51,12 +51,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
                 <configuration>
                     <configLocation>src/test/resources/checkstyle.xml</configLocation>
                     <linkXRef>false</linkXRef>
-                    <failOnViolation>true</failOnViolation>
                 </configuration>
             </plugin>
+            <!-- Javadoc -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
# Pull Request Template

## Checklist
_Make sure that you completed the following actions to submitting this PR._

* [X] There is an existing issue report for this PR. If not so, create one first.
* [X] I have forked this project.
* [X] I have created a feature branch.
* [X] My changes have been committed.
* [X] I have pushed my changes to the branch.
* [X] Running `mvn checkstyle:checkstyle` doesn't fail.

## Title
Checkstyle errors will no longer effect `mvn package`.

## Description
Checkstyle errors will no longer effect `mvn package`, but fails on `mvn checkstyle:check`.

## Issue Resolution
This Pull Request resolves #20 

## Proposed Changes
* Updates `.travis.yml`
* Changed checkstyle plugin rules
