### PR TITLE
Implement all request Minecraft Argument types

### DIFF
--- a/arguments/src/main/java/de/paul2708/commands/arguments/impl/spigot/EnchantmentArgument.java
+++ b/arguments/src/main/java/de/paul2708/commands/arguments/impl/spigot/EnchantmentArgument.java
@@ -1,0 +1,57 @@
+package de.paul2708.commands.arguments.impl.spigot;
+
+import com.google.common.collect.ImmutableList;
+import de.paul2708.commands.arguments.CommandArgument;
+import de.paul2708.commands.arguments.Validation;
+import de.paul2708.commands.language.MessageResource;
+import org.bukkit.NamespacedKey;
+import org.bukkit.enchantments.Enchantment;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author Stu (https://github.com/Stupremee)
+ * @since 19.10.19
+ */
+public final class EnchantmentArgument implements CommandArgument<Enchantment> {
+
+    @Override
+    public Validation<Enchantment> validate(String argument) {
+        if (argument.startsWith("minecraft:")) {
+            argument = argument.substring(10);
+        }
+
+        NamespacedKey key = NamespacedKey.minecraft(argument);
+        return Stream.of(Enchantment.values())
+                .filter(e -> e.getKey().equals(key))
+                .findFirst()
+                .map(Validation::valid)
+                .orElse(Validation.invalid(MessageResource.of("argument.enchantment.invalid", argument)));
+    }
+
+    @Override
+    public MessageResource usage() {
+        return MessageResource.of("argument.enchantment.usage");
+    }
+
+    @Override
+    public List<String> autoComplete(String argument) {
+        return Stream.of(Enchantment.values())
+                .filter(enchantment -> {
+                    NamespacedKey key = enchantment.getKey();
+                    return argument.startsWith(key.toString())
+                            || argument.startsWith(key.getNamespace())
+                            || argument.startsWith(key.getKey());
+                })
+                .map(enchantment -> enchantment.getKey().toString())
+                .collect(collectingAndThen(toList(), Collections::unmodifiableList));
+    }
+}

--- a/arguments/src/main/java/de/paul2708/commands/arguments/impl/spigot/EnchantmentArgument.java
+++ b/arguments/src/main/java/de/paul2708/commands/arguments/impl/spigot/EnchantmentArgument.java
@@ -1,16 +1,12 @@
 package de.paul2708.commands.arguments.impl.spigot;
 
-import com.google.common.collect.ImmutableList;
 import de.paul2708.commands.arguments.CommandArgument;
 import de.paul2708.commands.arguments.Validation;
 import de.paul2708.commands.language.MessageResource;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -25,16 +21,14 @@ public final class EnchantmentArgument implements CommandArgument<Enchantment> {
 
     @Override
     public Validation<Enchantment> validate(String argument) {
-        if (argument.startsWith("minecraft:")) {
-            argument = argument.substring(10);
-        }
+        String newArgument = argument.startsWith("minecraft:") ? argument.substring(10) : argument;
 
-        NamespacedKey key = NamespacedKey.minecraft(argument);
+        NamespacedKey key = NamespacedKey.minecraft(newArgument);
         return Stream.of(Enchantment.values())
                 .filter(e -> e.getKey().equals(key))
                 .findFirst()
                 .map(Validation::valid)
-                .orElse(Validation.invalid(MessageResource.of("argument.enchantment.invalid", argument)));
+                .orElse(Validation.invalid(MessageResource.of("argument.enchantment.invalid", newArgument)));
     }
 
     @Override

--- a/arguments/src/main/java/de/paul2708/commands/arguments/impl/spigot/GameRuleArgument.java
+++ b/arguments/src/main/java/de/paul2708/commands/arguments/impl/spigot/GameRuleArgument.java
@@ -1,0 +1,42 @@
+package de.paul2708.commands.arguments.impl.spigot;
+
+import de.paul2708.commands.arguments.CommandArgument;
+import de.paul2708.commands.arguments.Validation;
+import de.paul2708.commands.language.MessageResource;
+import org.bukkit.GameRule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author Stu (https://github.com/Stupremee)
+ * @since 19.10.19
+ */
+public final class GameRuleArgument implements CommandArgument<GameRule<?>> {
+    @Override
+    public Validation<GameRule<?>> validate(String argument) {
+        GameRule<?> gameRule = GameRule.getByName(argument);
+        if (gameRule == null) {
+            return Validation.invalid(MessageResource.of("argument.gamerule.invalid", argument));
+        } else {
+            return Validation.valid(gameRule);
+        }
+    }
+
+    @Override
+    public MessageResource usage() {
+        return MessageResource.of("argument.gamerule.usage");
+    }
+
+    @Override
+    public List<String> autoComplete(String argument) {
+        return Stream.of(GameRule.values())
+                .filter(rule -> rule.getName().startsWith(argument))
+                .map(GameRule::getName)
+                .collect(collectingAndThen(toList(), Collections::unmodifiableList));
+    }
+}

--- a/arguments/src/main/java/de/paul2708/commands/arguments/impl/spigot/UuidArgument.java
+++ b/arguments/src/main/java/de/paul2708/commands/arguments/impl/spigot/UuidArgument.java
@@ -1,0 +1,36 @@
+package de.paul2708.commands.arguments.impl.spigot;
+
+import de.paul2708.commands.arguments.CommandArgument;
+import de.paul2708.commands.arguments.Validation;
+import de.paul2708.commands.language.MessageResource;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * This command arguments represents a {@link UUID} argument.
+ *
+ * @author Stu (https://github.com/Stupremee)
+ * @since 19.10.19
+ */
+public final class UuidArgument implements CommandArgument<UUID> {
+
+  @Override
+  public Validation<UUID> validate(String argument) {
+    try {
+      return Validation.valid(UUID.fromString(argument));
+    } catch (IllegalArgumentException error) {
+      return Validation.invalid(MessageResource.of("argument.uuid.invalid"));
+    }
+  }
+
+  @Override
+  public MessageResource usage() {
+    return MessageResource.of("argument.uuid.usage");
+  }
+
+  @Override
+  public List<String> autoComplete(String argument) {
+    return Collections.emptyList();
+  }
+}

--- a/arguments/src/test/java/arguments/other/GameRuleArgumentTest.java
+++ b/arguments/src/test/java/arguments/other/GameRuleArgumentTest.java
@@ -1,0 +1,42 @@
+package arguments.other;
+
+import arguments.AbstractArgumentTest;
+import de.paul2708.commands.arguments.CommandArgument;
+import de.paul2708.commands.arguments.impl.spigot.GameRuleArgument;
+import de.paul2708.commands.arguments.impl.spigot.UuidArgument;
+import de.paul2708.commands.arguments.util.Pair;
+import org.bukkit.GameRule;
+
+import java.util.UUID;
+import java.util.function.Function;
+
+/**
+ * @author Stu (https://github.com/Stupremee)
+ * @since 19.10.19
+ */
+public final class GameRuleArgumentTest extends AbstractArgumentTest {
+
+    @Override
+    public CommandArgument<?> create() {
+        return new GameRuleArgument();
+    }
+
+    @Override
+    public Pair[] validArguments() {
+        Function<GameRule<?>, Pair<String, GameRule<?>>> makePair = rule -> Pair.of(rule.getName(), rule);
+
+        GameRule<?> first = GameRule.ANNOUNCE_ADVANCEMENTS;
+        GameRule<?> second = GameRule.DO_FIRE_TICK;
+        GameRule<?> third = GameRule.SEND_COMMAND_FEEDBACK;
+        return new Pair[]{
+                makePair.apply(first),
+                makePair.apply(second),
+                makePair.apply(third),
+        };
+    }
+
+    @Override
+    public String[] invalidArguments() {
+        return new String[]{"totally not a valid gamerule", "do fire tick"};
+    }
+}

--- a/arguments/src/test/java/arguments/other/UuidArgumentTest.java
+++ b/arguments/src/test/java/arguments/other/UuidArgumentTest.java
@@ -1,0 +1,40 @@
+package arguments.other;
+
+import arguments.AbstractArgumentTest;
+import de.paul2708.commands.arguments.CommandArgument;
+import de.paul2708.commands.arguments.impl.spigot.UuidArgument;
+import de.paul2708.commands.arguments.util.Pair;
+
+import java.util.UUID;
+import java.util.function.Function;
+
+/**
+ * @author Stu (https://github.com/Stupremee)
+ * @since 19.10.19
+ */
+public final class UuidArgumentTest extends AbstractArgumentTest {
+
+    @Override
+    public CommandArgument<?> create() {
+        return new UuidArgument();
+    }
+
+    @Override
+    public Pair[] validArguments() {
+        Function<UUID, Pair<String, UUID>> makePair = uuid -> Pair.of(uuid.toString(), uuid);
+
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        UUID third = UUID.randomUUID();
+        return new Pair[]{
+                makePair.apply(first),
+                makePair.apply(second),
+                makePair.apply(third),
+        };
+    }
+
+    @Override
+    public String[] invalidArguments() {
+        return new String[]{"totally not a valid uuid", "0011-1232-1234-1234"};
+    }
+}

--- a/language/src/main/resources/messages_de.properties
+++ b/language/src/main/resources/messages_de.properties
@@ -19,7 +19,8 @@ argument.location.invalid.world=%prefix% Weltenname ''{0}'' trifft auf keine Wel
 argument.location.invalid.x=%prefix% Die X Koordinate ''{0}'' ist keine valide Ganzzahl.
 argument.location.invalid.y=%prefix% Die Y Koordinate ''{0}'' ist keine valide Ganzzahl.
 argument.location.invalid.z=%prefix% Die Z Koordinate ''{0}'' ist keine valide Ganzzahl.
-argument.uuid.invalid=Bitte gib eine gültige UUID an.
+argument.uuid.invalid=%prefix% Bitte gib eine gültige UUID an.
+argument.gamerule.invalid=%prefix% Die Gamerule ''{0}'' existiert nicht.
 
 argument.boolean.usage=[wahr/falsch]
 argument.byte.usage=[-128 bis 127]
@@ -35,6 +36,7 @@ argument.world.usage=[Welt]
 argument.entity.usage=[Mob]
 argument.location.usage=[Welt,X,Y,Z]
 argument.uuid.usage=[UUID]
+argument.gamerule.usage=[Gamerule Name]
 
 # Allgemeine Command-Nachrichten
 command.only_players=%prefix% Du kannst den Befehl nicht ausführen, nur Spieler erlaubt.

--- a/language/src/main/resources/messages_de.properties
+++ b/language/src/main/resources/messages_de.properties
@@ -19,6 +19,7 @@ argument.location.invalid.world=%prefix% Weltenname ''{0}'' trifft auf keine Wel
 argument.location.invalid.x=%prefix% Die X Koordinate ''{0}'' ist keine valide Ganzzahl.
 argument.location.invalid.y=%prefix% Die Y Koordinate ''{0}'' ist keine valide Ganzzahl.
 argument.location.invalid.z=%prefix% Die Z Koordinate ''{0}'' ist keine valide Ganzzahl.
+argument.uuid.invalid=Bitte gib eine gültige UUID an.
 
 argument.boolean.usage=[wahr/falsch]
 argument.byte.usage=[-128 bis 127]
@@ -33,6 +34,7 @@ argument.string.usage=[Wort]
 argument.world.usage=[Welt]
 argument.entity.usage=[Mob]
 argument.location.usage=[Welt,X,Y,Z]
+argument.uuid.usage=[UUID]
 
 # Allgemeine Command-Nachrichten
 command.only_players=%prefix% Du kannst den Befehl nicht ausführen, nur Spieler erlaubt.

--- a/language/src/main/resources/messages_de.properties
+++ b/language/src/main/resources/messages_de.properties
@@ -21,6 +21,7 @@ argument.location.invalid.y=%prefix% Die Y Koordinate ''{0}'' ist keine valide G
 argument.location.invalid.z=%prefix% Die Z Koordinate ''{0}'' ist keine valide Ganzzahl.
 argument.uuid.invalid=%prefix% Bitte gib eine gültige UUID an.
 argument.gamerule.invalid=%prefix% Die Gamerule ''{0}'' existiert nicht.
+argument.enchantment.invalid=%prefix% Das Enchantment ''{0}'' existiert nicht.
 
 argument.boolean.usage=[wahr/falsch]
 argument.byte.usage=[-128 bis 127]
@@ -37,6 +38,7 @@ argument.entity.usage=[Mob]
 argument.location.usage=[Welt,X,Y,Z]
 argument.uuid.usage=[UUID]
 argument.gamerule.usage=[Gamerule Name]
+argument.enchantment.usage=[Enchantment]
 
 # Allgemeine Command-Nachrichten
 command.only_players=%prefix% Du kannst den Befehl nicht ausführen, nur Spieler erlaubt.

--- a/language/src/main/resources/messages_en.properties
+++ b/language/src/main/resources/messages_en.properties
@@ -21,6 +21,7 @@ argument.location.invalid.y=%prefix% Given y coordinate ''{0}'' is not a valid I
 argument.location.invalid.z=%prefix% Given z coordinate ''{0}'' is not a valid Integer.
 argument.uuid.invalid=%prefix% Please provide a valid uuid.
 argument.gamerule.invalid=%prefix% The gamerule ''{0}'' doesn't exist.
+argument.enchantment.invalid=%prefix% The enchantment ''{0}'' doesn't exist.
 
 argument.boolean.usage=[true/false]
 argument.byte.usage=[-128 to 127]
@@ -37,6 +38,7 @@ argument.entity.usage=[Entity]
 argument.location.usage=[World,X,Y,Z]
 argument.uuid.usage=[UUID]
 argument.gamerule.usage=[Gamerule Name]
+argument.enchantment.usage=[Enchantment]
 
 # General command messages
 command.only_players=%prefix% You cannot execute this command, only players allowed.

--- a/language/src/main/resources/messages_en.properties
+++ b/language/src/main/resources/messages_en.properties
@@ -19,7 +19,8 @@ argument.location.invalid.world=%prefix% Given world name ''{0}'' does not match
 argument.location.invalid.x=%prefix% Given x coordinate ''{0}'' is not a valid Integer.
 argument.location.invalid.y=%prefix% Given y coordinate ''{0}'' is not a valid Integer.
 argument.location.invalid.z=%prefix% Given z coordinate ''{0}'' is not a valid Integer.
-argument.uuid.invalid=Please provide a valid uuid.
+argument.uuid.invalid=%prefix% Please provide a valid uuid.
+argument.gamerule.invalid=%prefix% The gamerule ''{0}'' doesn't exist.
 
 argument.boolean.usage=[true/false]
 argument.byte.usage=[-128 to 127]
@@ -35,6 +36,7 @@ argument.world.usage=[World]
 argument.entity.usage=[Entity]
 argument.location.usage=[World,X,Y,Z]
 argument.uuid.usage=[UUID]
+argument.gamerule.usage=[Gamerule Name]
 
 # General command messages
 command.only_players=%prefix% You cannot execute this command, only players allowed.

--- a/language/src/main/resources/messages_en.properties
+++ b/language/src/main/resources/messages_en.properties
@@ -19,6 +19,7 @@ argument.location.invalid.world=%prefix% Given world name ''{0}'' does not match
 argument.location.invalid.x=%prefix% Given x coordinate ''{0}'' is not a valid Integer.
 argument.location.invalid.y=%prefix% Given y coordinate ''{0}'' is not a valid Integer.
 argument.location.invalid.z=%prefix% Given z coordinate ''{0}'' is not a valid Integer.
+argument.uuid.invalid=Please provide a valid uuid.
 
 argument.boolean.usage=[true/false]
 argument.byte.usage=[-128 to 127]
@@ -33,6 +34,7 @@ argument.string.usage=[Word]
 argument.world.usage=[World]
 argument.entity.usage=[Entity]
 argument.location.usage=[World,X,Y,Z]
+argument.uuid.usage=[UUID]
 
 # General command messages
 command.only_players=%prefix% You cannot execute this command, only players allowed.


### PR DESCRIPTION
# Pull Request Template

## Checklist
_Make sure that you completed the following actions to submitting this PR._

* [x] There is an existing issue report for this PR. If not so, create one first.
* [x] I have forked this project.
* [x] I have created a feature branch.
* [x] My changes have been committed.
* [x] I have pushed my changes to the branch.
* [x] Running `mvn checkstyle:check` doesn't fail.

## Title
Implement minecraft specific arguments.

## Description
This PR implements argument parsers for Uuid, GameRule and Echantment with a corresponding unit test.

## Issue Resolution
This Pull Request addresses #27 

## Proposed Changes
*List your proposed changes.*

* Add UuidArgument, GameRuleArgument and EnchantmentArgument
* Add unit tests for the three arguments
