### PR TITLE
Added support for optional arguments

### DIFF
--- a/arguments/src/main/java/de/paul2708/commands/arguments/CommandArgument.java
+++ b/arguments/src/main/java/de/paul2708/commands/arguments/CommandArgument.java
@@ -50,4 +50,21 @@ public interface CommandArgument<T> {
             throw new NotFulfilledConditionException(description);
         }
     }
+
+    /**
+     * @return this argument as an optional argument
+     * @see CommandArgument#isOptional()
+     */
+    default CommandArgument<T> asOptional() {
+        return new OptionalArgument<>(this);
+    }
+
+    /**
+     * An optional argument may be skipped by the argument parser
+     *
+     * @return whether this argument is optional
+     */
+    default boolean isOptional() {
+        return false;
+    }
 }

--- a/arguments/src/main/java/de/paul2708/commands/arguments/OptionalArgument.java
+++ b/arguments/src/main/java/de/paul2708/commands/arguments/OptionalArgument.java
@@ -5,7 +5,8 @@ import de.paul2708.commands.language.MessageResource;
 import java.util.List;
 
 /**
- * An argument which is marked as Optional to the argument parser. This can be received via {@link CommandArgument#asOptional()}
+ * An argument which is marked as Optional to the argument parser. This can be received via
+ * {@link CommandArgument#asOptional()}
  * @param <T> The type of this argument
  */
 public class OptionalArgument<T> implements CommandArgument<T> {

--- a/arguments/src/main/java/de/paul2708/commands/arguments/OptionalArgument.java
+++ b/arguments/src/main/java/de/paul2708/commands/arguments/OptionalArgument.java
@@ -1,0 +1,39 @@
+package de.paul2708.commands.arguments;
+
+import de.paul2708.commands.language.MessageResource;
+
+import java.util.List;
+
+public class OptionalArgument<T> implements CommandArgument<T> {
+    private CommandArgument<T> internal;
+
+    OptionalArgument(CommandArgument<T> internal) {
+        this.internal = internal;
+    }
+
+    @Override
+    public Validation<T> validate(String argument) {
+        return internal.validate(argument);
+    }
+
+    @Override
+    public MessageResource usage() {
+        // TODO: Append hint about optionality to usage?
+        return internal.usage();
+    }
+
+    @Override
+    public List<String> autoComplete(String argument) {
+        return internal.autoComplete(argument);
+    }
+
+    @Override
+    public CommandArgument<T> asOptional() {
+        return this;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return true;
+    }
+}

--- a/arguments/src/main/java/de/paul2708/commands/arguments/OptionalArgument.java
+++ b/arguments/src/main/java/de/paul2708/commands/arguments/OptionalArgument.java
@@ -4,9 +4,17 @@ import de.paul2708.commands.language.MessageResource;
 
 import java.util.List;
 
+/**
+ * An argument which is marked as Optional to the argument parser. This can be received via {@link CommandArgument#asOptional()}
+ * @param <T> The type of this argument
+ */
 public class OptionalArgument<T> implements CommandArgument<T> {
     private CommandArgument<T> internal;
 
+    /**
+     * For internal use only. Use {@link CommandArgument#asOptional()} instead.
+     * @param internal the internal argument which will be called for any parsing
+     */
     OptionalArgument(CommandArgument<T> internal) {
         this.internal = internal;
     }

--- a/core/src/main/java/de/paul2708/commands/core/DefaultCommandRegistry.java
+++ b/core/src/main/java/de/paul2708/commands/core/DefaultCommandRegistry.java
@@ -135,9 +135,9 @@ public final class DefaultCommandRegistry implements CommandRegistry {
                                     + "an argument wrapper", type.getName(), method.getName()));
                         }
 
-                        if(isOptional)
+                        if (isOptional) {
                             argument = argument.asOptional();
-
+                        }
                         list.add(argument);
                     }
 

--- a/core/src/main/java/de/paul2708/commands/core/DefaultCommandRegistry.java
+++ b/core/src/main/java/de/paul2708/commands/core/DefaultCommandRegistry.java
@@ -5,6 +5,7 @@ import de.paul2708.commands.arguments.CommandArgument;
 import de.paul2708.commands.arguments.util.Pair;
 import de.paul2708.commands.core.annotation.Command;
 import de.paul2708.commands.core.annotation.Inject;
+import de.paul2708.commands.core.annotation.Optional;
 import de.paul2708.commands.core.command.BasicCommand;
 import de.paul2708.commands.core.command.CommandType;
 import de.paul2708.commands.core.command.SimpleCommand;
@@ -125,6 +126,7 @@ public final class DefaultCommandRegistry implements CommandRegistry {
 
                     for (int i = 1; i < parameters.length; i++) {
                         Class<?> type = parameters[i].getType();
+                        boolean isOptional = parameters[i].getAnnotation(Optional.class) != null;
 
                         CommandArgument<?> argument = argumentHolder.resolve(type);
 
@@ -132,6 +134,9 @@ public final class DefaultCommandRegistry implements CommandRegistry {
                             throw new IllegalArgumentException(String.format("parameter %s of method %s doesn't have "
                                     + "an argument wrapper", type.getName(), method.getName()));
                         }
+
+                        if(isOptional)
+                            argument = argument.asOptional();
 
                         list.add(argument);
                     }

--- a/core/src/main/java/de/paul2708/commands/core/annotation/Optional.java
+++ b/core/src/main/java/de/paul2708/commands/core/annotation/Optional.java
@@ -1,0 +1,16 @@
+package de.paul2708.commands.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation marks an argument as optional. This causes it to be skipped in case of failure while converting the
+ * argument. This cannot be applied to primitives such as int, or bool, but to their respective boxed classes like
+ * {@link Integer} and {@link Boolean}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Optional {
+}

--- a/core/src/main/java/de/paul2708/commands/core/command/BasicCommand.java
+++ b/core/src/main/java/de/paul2708/commands/core/command/BasicCommand.java
@@ -92,7 +92,7 @@ public final class BasicCommand extends Command {
         for (int i = 0; i < args.length; i++) {
             if (!arguments.hasNext()) {
                 sendUsage(sender, simpleCommand.getArguments());
-                for(Validation<?> validation: errors){
+                for (Validation<?> validation : errors) {
                     languageSelector.sendMessage(sender, validation.getErrorResource());
                 }
                 return false;
@@ -102,7 +102,7 @@ public final class BasicCommand extends Command {
             parameters.add(validate.getParsedObject());
 
             if (!validate.isValid()) {
-                if(argument.isOptional()){
+                if (argument.isOptional()) {
                     i--;
                     // i will be incremented at the end of the loop causing this text argument to be processed once
                     //more
@@ -115,9 +115,9 @@ public final class BasicCommand extends Command {
                 return false;
             }
         }
-        System.out.println(parameters);
+
         // If any arguments are left, you passed to few arguments.
-        if(arguments.hasNext()){
+        if (arguments.hasNext()) {
             sendUsage(sender, simpleCommand.getArguments());
         }
 
@@ -143,6 +143,11 @@ public final class BasicCommand extends Command {
         }
     }
 
+    /**
+     * private helper to send usage to a CommandSender
+     * @param sender the sender to send the usage to
+     * @param arguments the required arguments of the command
+     */
     private void sendUsage(CommandSender sender, List<CommandArgument<?>> arguments) {
         StringBuilder usage = new StringBuilder("/" + simpleCommand.getInformation().name() + " ");
 

--- a/core/src/main/java/de/paul2708/commands/core/command/BasicCommand.java
+++ b/core/src/main/java/de/paul2708/commands/core/command/BasicCommand.java
@@ -11,7 +11,9 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -80,37 +82,46 @@ public final class BasicCommand extends Command {
         }
 
         // Check arguments
-        List<CommandArgument<?>> arguments = simpleCommand.getArguments();
-        if (arguments.size() != args.length) {
-            StringBuilder usage = new StringBuilder("/" + simpleCommand.getInformation().name() + " ");
+        Iterator<CommandArgument<?>> arguments = simpleCommand.getArguments().iterator();
 
-            for (CommandArgument<?> argument : arguments) {
-                usage.append(languageSelector.translate(sender, argument.usage())).append(" ");
-            }
 
-            languageSelector.sendMessage(sender, MessageResource.of("command.false_usage", usage.toString()));
-            return false;
-        }
-
-        for (int i = 0; i < args.length; i++) {
-            Validation<?> validate = arguments.get(i).validate(args[i]);
-
-            if (!validate.isValid()) {
-                languageSelector.sendMessage(sender, validate.getErrorResource());
-                return false;
-            }
-        }
-
-        // Execute command
+        List<Validation<?>> errors = new ArrayList<>();
         List<Object> parameters = new LinkedList<>();
         parameters.add(sender);
 
         for (int i = 0; i < args.length; i++) {
-            Validation<?> validate = arguments.get(i).validate(args[i]);
-
+            if (!arguments.hasNext()) {
+                sendUsage(sender, simpleCommand.getArguments());
+                for(Validation<?> validation: errors){
+                    languageSelector.sendMessage(sender, validation.getErrorResource());
+                }
+                return false;
+            }
+            CommandArgument<?> argument = arguments.next();
+            Validation<?> validate = argument.validate(args[i]);
             parameters.add(validate.getParsedObject());
+
+            if (!validate.isValid()) {
+                if(argument.isOptional()){
+                    i--;
+                    // i will be incremented at the end of the loop causing this text argument to be processed once
+                    //more
+                    errors.add(validate);
+                    // We will take note, so if the command still fails we can still report this
+                    // error
+                    continue;
+                }
+                languageSelector.sendMessage(sender, validate.getErrorResource());
+                return false;
+            }
+        }
+        System.out.println(parameters);
+        // If any arguments are left, you passed to few arguments.
+        if(arguments.hasNext()){
+            sendUsage(sender, simpleCommand.getArguments());
         }
 
+        // Execute command
         try {
             simpleCommand.getMethod().invoke(simpleCommand.getObject(), parameters.toArray());
             return true;
@@ -130,6 +141,16 @@ public final class BasicCommand extends Command {
             e.printStackTrace();
             return false;
         }
+    }
+
+    private void sendUsage(CommandSender sender, List<CommandArgument<?>> arguments) {
+        StringBuilder usage = new StringBuilder("/" + simpleCommand.getInformation().name() + " ");
+
+        for (CommandArgument<?> argument : arguments) {
+            usage.append(languageSelector.translate(sender, argument.usage())).append(" ");
+        }
+
+        languageSelector.sendMessage(sender, MessageResource.of("command.false_usage", usage.toString()));
     }
 
     /**

--- a/example/src/main/java/de/paul2708/commands/example/TestCommand.java
+++ b/example/src/main/java/de/paul2708/commands/example/TestCommand.java
@@ -2,6 +2,7 @@ package de.paul2708.commands.example;
 
 import de.paul2708.commands.core.annotation.Command;
 import de.paul2708.commands.core.annotation.Inject;
+import de.paul2708.commands.core.annotation.Optional;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
@@ -59,5 +60,15 @@ public final class TestCommand {
         // ...
 
         sender.sendMessage("You set the age for: " + person.toString());
+    }
+
+    /**
+     * Do some fancy optional stuff
+     */
+    @Command(name = "optcmd", desc = "Optionally specify a number")
+    public void optionalTest(CommandSender sender, @Optional Integer integer, String text) {
+        integer = integer != null ? integer : -1;
+        sender.sendMessage(String.format("You send the string: %s and the number %d (-1 if none specified)",
+                text, integer));
     }
 }

--- a/example/src/main/java/de/paul2708/commands/example/TestCommand.java
+++ b/example/src/main/java/de/paul2708/commands/example/TestCommand.java
@@ -64,11 +64,15 @@ public final class TestCommand {
 
     /**
      * Do some fancy optional stuff
+     *
+     * @param sender sender who send the request
+     * @param integer a number to be given back to the sender (optional)
+     * @param text a text to be given back to the sender
      */
     @Command(name = "optcmd", desc = "Optionally specify a number")
     public void optionalTest(CommandSender sender, @Optional Integer integer, String text) {
-        integer = integer != null ? integer : -1;
+        int actualValue = integer != null ? integer : -1;
         sender.sendMessage(String.format("You send the string: %s and the number %d (-1 if none specified)",
-                text, integer));
+                text, actualValue));
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Checklist
_Make sure that you completed the following actions to submitting this PR._

* [x] There is an existing issue report for this PR. If not so, create one first.
* [x] I have forked this project.
* [x] I have created a feature branch.
* [x] My changes have been committed.
* [x] I have pushed my changes to the branch.
* [ ] Running `mvn checkstyle:check` doesn't fail.

I can't run `mvn checkstyle:check` as all mvn commands fail for me. However i tested my IDEs build tool which worked and also didn't find any style issues. So this is something rather to my maven setup which can't be fixed rn.

## Title
Added support for optional arguments.

## Description
This adds support for optional arguments via an `@Optional` annotation.
If this annotation is applied to an argument this argument will be
skipped during argument parsing if the `CommandArgument` returns an
invalid Validator. The method will have a null passed instead.

This should be backwards compatible.

## Issue Resolution
Closes #11 


## Proposed Changes

* Adds optional arguments to the argument package
* Makes the BasicCommand argument parser respect optional arguments by ignoring failures on them.
