### PR TITLE
Fix enum argument

### DIFF
--- a/arguments/src/main/java/de/paul2708/commands/arguments/impl/EnumArgument.java
+++ b/arguments/src/main/java/de/paul2708/commands/arguments/impl/EnumArgument.java
@@ -38,7 +38,7 @@ public final class EnumArgument<T> implements CommandArgument<T> {
     @Override
     public Validation<T> validate(String argument) {
         for (T enumValue : enumClass.getEnumConstants()) {
-            if (enumValue.toString().equals(argument.toUpperCase())) {
+            if (enumValue.toString().toUpperCase().equals(argument.toUpperCase())) {
                 return Validation.valid(enumValue);
             }
         }

--- a/arguments/src/test/java/arguments/other/WeirdEnumArgumentTest.java
+++ b/arguments/src/test/java/arguments/other/WeirdEnumArgumentTest.java
@@ -1,0 +1,61 @@
+package arguments.other;
+
+import arguments.AbstractArgumentTest;
+import de.paul2708.commands.arguments.CommandArgument;
+import de.paul2708.commands.arguments.impl.EnumArgument;
+import de.paul2708.commands.arguments.util.Pair;
+
+/**
+ * This class tests an enum, that doesn't go along with the conventions.
+ *
+ * @author Paul2708
+ */
+public final class WeirdEnumArgumentTest extends AbstractArgumentTest {
+
+    /**
+     * Enum with different upper- and lower-sensitive constants.
+     */
+    private enum WeirdEnum {
+        UPPERCASE, lowercase, mIxEd
+    }
+
+    /**
+     * Create a new command argument.
+     *
+     * @return command argument.
+     */
+    @Override
+    public CommandArgument<?> create() {
+        return new EnumArgument<>(WeirdEnum.class);
+    }
+
+    /**
+     * Get an array of pairs, that provide the correct object to the argument.
+     *
+     * @return array of pairs
+     */
+    @Override
+    public Pair[] validArguments() {
+        return new Pair[] {
+                Pair.of("UPPERCASE", WeirdEnum.UPPERCASE),
+                Pair.of("lowercase", WeirdEnum.lowercase),
+                Pair.of("mIxEd", WeirdEnum.mIxEd),
+                Pair.of("uppercase", WeirdEnum.UPPERCASE),
+                Pair.of("LOWERCASE", WeirdEnum.lowercase),
+                Pair.of("MiXeD", WeirdEnum.mIxEd)
+        };
+    }
+
+    /**
+     * Get an array of string arguments.
+     *
+     * @return array of strings
+     */
+    @Override
+    public String[] invalidArguments() {
+        return new String[] {
+                "not_defined",
+                "WeirdEnum.lowercase"
+        };
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Checklist
_Make sure that you completed the following actions to submitting this PR._

* [X] There is an existing issue report for this PR. If not so, create one first.
* [X] I have forked this project.
* [X] I have created a feature branch.
* [X] My changes have been committed.
* [X] I have pushed my changes to the branch.
* [X] Running `mvn checkstyle:check` doesn't fail.

## Title
Fixes an enum argument bug

## Description
If an enum constant wasn't in uppercase, an argument with the same chars but with different upper- and lower-case got rejected.
This issue got fixed by transform every the enum constant to uppercase.

## Issue Resolution
_The issue addressed by this PR._

This Pull Request fixes #46 

## Proposed Changes
*List your proposed changes.*

* transform enum constant in `EnumArgument` to uppercase
* unit test that ensures the correct behavior with mixed lower- and uppercase constants
